### PR TITLE
Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.8)
+project(libaesgm LANGUAGES C)
+
+add_library(aesgm
+    #sources
+    ${CMAKE_CURRENT_SOURCE_DIR}/aescrypt.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/aeskey.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes_modes.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes_ni.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/aestab.c
+    #headers
+    ${CMAKE_CURRENT_SOURCE_DIR}/aescpp.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes_ni.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aesopt.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aestab.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes_via_ace.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/brg_endian.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/brg_types.h
+)
+
+target_include_directories(aesgm
+    INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/libaesgm>
+)
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    target_compile_definitions(aesgm PRIVATE DLL_EXPORT)
+endif()
+
+install(TARGETS aesgm
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+install(
+    FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes_ni.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aes_via_ace.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aescpp.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aesopt.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/aestab.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/brg_endian.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/brg_types.h
+    DESTINATION include
+)


### PR DESCRIPTION
This CMakeLists.txt comes from https://github.com/conan-io/conan-center-index/pull/19426 kudos to @toge!

Build log:

```
% cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/tmp/install 
-- The C compiler identification is AppleClang 14.0.3.14030022
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /tmp/libaesgm/build
% cmake --build build                                    
[ 16%] Building C object CMakeFiles/aesgm.dir/aescrypt.c.o
[ 33%] Building C object CMakeFiles/aesgm.dir/aeskey.c.o
[ 50%] Building C object CMakeFiles/aesgm.dir/aes_modes.c.o
[ 66%] Building C object CMakeFiles/aesgm.dir/aes_ni.c.o
[ 83%] Building C object CMakeFiles/aesgm.dir/aestab.c.o
[100%] Linking C static library libaesgm.a
[100%] Built target aesgm
% cmake --build build --target install
[100%] Built target aesgm
Install the project...
-- Install configuration: ""
-- Installing: /tmp/install/lib/libaesgm.a
-- Installing: /tmp/install/include/aes.h
-- Installing: /tmp/install/include/aes_ni.h
-- Installing: /tmp/install/include/aes_via_ace.h
-- Installing: /tmp/install/include/aescpp.h
-- Installing: /tmp/install/include/aesopt.h
-- Installing: /tmp/install/include/aestab.h
-- Installing: /tmp/install/include/brg_endian.h
-- Installing: /tmp/install/include/brg_types.h
```